### PR TITLE
Move report copy to cleanup stage to have them even in case of scan failure

### DIFF
--- a/scripts/inline_scan
+++ b/scripts/inline_scan
@@ -393,11 +393,6 @@ start_vuln_scan() {
         echo
         docker start -ia "${DOCKER_NAME}"
     fi
-
-    if [[ "${r_flag}" ]]; then
-        echo "Copying scan reports from ${DOCKER_NAME} to ${PWD}/anchore-reports/"
-        docker cp "${DOCKER_NAME}:/anchore-engine/anchore-reports/" ./
-    fi
 }
 
 start_analysis() {
@@ -525,6 +520,10 @@ cleanup() {
     for id in ${DOCKER_ID}; do
         local -i timeout=0
         while (docker ps -a | grep "${id:0:10}") > /dev/null && [[ "${timeout}" -lt 12 ]]; do
+            if [[ "${r_flag}" ]]; then
+                echo "Copying scan reports from ${DOCKER_NAME} to ${PWD}/anchore-reports/"
+                docker cp "${DOCKER_NAME}:/anchore-engine/anchore-reports/" ./
+            fi
             docker kill "${id}" &> /dev/null
             docker rm "${id}" &> /dev/null
             printf '\n%s\n' "Cleaning up docker container: ${id}"


### PR DESCRIPTION
Move report copy to cleanup stage to have them even in case of scan failure.

Fix #24

Explain why this change is being made.
---
Report were not generated when both -r and -f options were used, and when scan is failing.


Explain how this is accomplished.
---
I tried a lot of things, but this script is not really easy to maintain. The cleanest way I found was to move the report copy step in the cleanup stage, which is not a bad stage for that either.


Merge/Deploy Checklist
----

- [ ] It has been reviewed for code quality.
- [ ] It has been visually reviewed and accepted.

How do you manually test this?
----
`inline_scan -p -r -f ubuntu:latest` will generate reports, before and after the change.
`inline_scan -p -r -f alpine:3.7` will **NOT** generate reports before, and it will generate reports after the change


Screenshots
----

| Desktop | Mobile |
|--|--|
| image_placeholder | image_placeholder |
