### PR TITLE
Consolidate the YAML and thus jobs for nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,16 +125,6 @@ workflows:
           name: build_test_push_inline_slim_v073
           anchore_version: v0.7.3
           context: dockerhub
-
-  nightly_build_images:
-    triggers:
-      - schedule:
-          cron: "0 12 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
       - build_test_push_inline_image:
           name: build_test_push_inline_image_v061
           anchore_version: v0.6.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
             - build_test_push_inline_image_all
             - build_test_push_inline_slim_all
 
-  nightly_build_slim_images:
+  nightly_build_images:
     triggers:
       - schedule:
           cron: "0 12 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
             - build_test_push_inline_image_all
             - build_test_push_inline_slim_all
 
-  nightly_build_images:
+  nightly_build:
     triggers:
       - schedule:
           cron: "0 12 * * *"


### PR DESCRIPTION
This makes ci-tools CircleCI YAML section for nightly builds almost the
same as engine-db-preload, which makes it nicer for a single piece of
code to automagically bump the versions when the inline_scan version
gets updated.

Signed-off-by: Robert Prince <robert.prince@anchore.com>