### PR TITLE
Rprince/fix keyserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex; \
     curl -Lo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
     curl -Lo /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --batch --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --import /usr/local/bin/jq-public.asc; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
     gpg --batch --verify /usr/local/bin/jq.asc /usr/local/bin/jq; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex; \
     curl -Lo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
     curl -Lo /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --import /usr/local/bin/jq-public.asc; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
     gpg --batch --verify /usr/local/bin/jq.asc /usr/local/bin/jq; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex; \
     curl -Lo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
     curl -Lo /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --import /usr/local/bin/jq-public.asc; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
     gpg --batch --verify /usr/local/bin/jq.asc /usr/local/bin/jq; \

--- a/scripts/inline_scan
+++ b/scripts/inline_scan
@@ -24,7 +24,7 @@ VALIDATED_OPTIONS=""
 # Vuln scan option variable defaults
 DOCKERFILE="./Dockerfile"
 POLICY_BUNDLE="./policy_bundle.json"
-TIMEOUT=300
+TIMEOUT=600
 VOLUME_PATH="/tmp/"
 # Analyzer option variable defaults
 ANCHORE_URL="http://localhost:8228"


### PR DESCRIPTION
The long-used pool of key servers (sks-keyservers) are decommissioned (see https://sks-keyservers.net/) and is no longer available. Switching to keys.openpgp.org.