### PR TITLE
Delete the long-dead circleci-orbs directory

### DIFF
--- a/circleci-orbs/README.md
+++ b/circleci-orbs/README.md
@@ -1,2 +1,0 @@
-# Anchore CircleCi Orbs
-Source code for all CircleCi orbs has been moved to a new [GitHub Repository](https://github.com/anchore/circleci-orbs).

--- a/circleci-orbs/anchore-engine/README.md
+++ b/circleci-orbs/anchore-engine/README.md
@@ -1,2 +1,0 @@
-# Anchore CircleCi Orbs
-Source code for the Anchore Engine orb has been moved to a new [GitHub Repository](https://github.com/anchore/circleci-orbs/tree/master/anchore-engine).


### PR DESCRIPTION
Removes dir not updated in 2 years and no longer used.